### PR TITLE
Exclude query parameters from mparticle request

### DIFF
--- a/src/serverModel.js
+++ b/src/serverModel.js
@@ -279,7 +279,8 @@ export default function ServerModel(mpInstance) {
             dto.fr = isFirstRun;
             dto.iu = false;
             dto.at = ApplicationTransitionType.AppInit;
-            dto.lr = window.location.href || null;
+            // Note(colin) exclude query parameters
+            dto.lr = window.location.href.split("?")[0] || null;
             dto.attrs = null;
         }
 


### PR DESCRIPTION
## Summary
Per, https://github.com/postmates/buyer-frontend/issues/5313, we need to stop sending sensitive query parameters to Mparticle. Mparticle is working on an SDK change to add a configuration option which allows sanitizing the URL of query parameters. However, we plan on self hosting a forked version of the Mparticle SDK with this change until the new configuration option is available. 

